### PR TITLE
Fixed issue where akka-js-actor-tests would not complete or Node.js reported an error

### DIFF
--- a/akka-js-actor-tests/js/src/test/scala/akka/actor/UidClashTest.scala
+++ b/akka-js-actor-tests/js/src/test/scala/akka/actor/UidClashTest.scala
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.actor
+
+import akka.testkit.{ TestProbe, AkkaSpec }
+import akka.actor.SupervisorStrategy.{ Restart, Stop }
+import akka.dispatch.sysmsg.SystemMessage
+import akka.event.EventStream
+import scala.util.control.NoStackTrace
+
+object UidClashTest {
+
+  class TerminatedForNonWatchedActor extends Exception("Received Terminated for actor that was not actually watched")
+    with NoStackTrace
+
+  @volatile var oldActor: ActorRef = _
+
+  private[akka] class EvilCollidingActorRef(
+    override val provider: ActorRefProvider,
+    override val path:     ActorPath,
+    val eventStream:       EventStream) extends MinimalActorRef {
+
+    //Ignore everything
+    override def isTerminated: Boolean = true
+    override def sendSystemMessage(message: SystemMessage): Unit = ()
+    override def !(message: Any)(implicit sender: ActorRef = Actor.noSender): Unit = ()
+  }
+
+  def createCollidingRef(system: ActorSystem): ActorRef =
+    new EvilCollidingActorRef(system.asInstanceOf[ActorSystemImpl].provider, oldActor.path, system.eventStream)
+
+  case object PleaseRestart
+  case object PingMyself
+  case object RestartedSafely
+
+  class RestartedActor extends Actor {
+
+    def receive = {
+      case PleaseRestart   ⇒ throw new Exception("restart")
+      case Terminated(ref) ⇒ throw new TerminatedForNonWatchedActor
+      // This is the tricky part to make this test a positive one (avoid expectNoMsg).
+      // Since anything enqueued in postRestart will arrive before the Terminated
+      // the bug triggers, there needs to be a bounce:
+      // 1. Ping is sent from postRestart to self
+      // 2. As a response to pint, RestartedSafely is sent to self
+      // 3a. if Terminated was enqueued during the restart procedure it will arrive before the RestartedSafely message
+      // 3b. otherwise only the RestartedSafely message arrives
+      case PingMyself      ⇒ self ! RestartedSafely
+      case RestartedSafely ⇒ context.parent ! RestartedSafely
+    }
+
+    override def preRestart(reason: Throwable, message: Option[Any]): Unit = {
+      context.children foreach { child ⇒
+        oldActor = child
+        context.unwatch(child)
+        context.stop(child)
+      }
+    }
+
+    override def preStart(): Unit = context.watch(context.actorOf(Props.empty, "child"))
+
+    override def postRestart(reason: Throwable): Unit = {
+      context.watch(createCollidingRef(context.system))
+      self ! PingMyself
+    } // Simulate UID clash
+  }
+
+  class RestartingActor(probe: ActorRef) extends Actor {
+    override val supervisorStrategy = OneForOneStrategy(loggingEnabled = false) {
+      case _: TerminatedForNonWatchedActor ⇒
+        context.stop(self)
+        Stop
+      case _ ⇒ Restart
+    }
+    val theRestartedOne = context.actorOf(Props(new RestartedActor()),"theRestartedOne")
+
+    def receive = {
+      case PleaseRestart   ⇒ theRestartedOne ! PleaseRestart
+      case RestartedSafely ⇒ probe ! RestartedSafely
+    }
+  }
+
+}
+
+class UidClashTest extends AkkaSpec {
+  import UidClashTest._
+
+  "The Terminated message for an old child stopped in preRestart" should {
+    "not arrive after restart" in {
+      val watcher = TestProbe()
+      val topActor = system.actorOf(Props(new RestartingActor(watcher.ref)), "top")
+      watcher.watch(topActor)
+
+      topActor ! PleaseRestart
+      watcher.expectMsg(RestartedSafely)
+    }
+  }
+
+}

--- a/akka-js-actor-tests/js/src/test/scala/akka/event/AddressTerminatedTopicBenchSpec.scala
+++ b/akka-js-actor-tests/js/src/test/scala/akka/event/AddressTerminatedTopicBenchSpec.scala
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.event
+
+import scala.concurrent.duration._
+import akka.actor.Actor
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.Props
+import akka.testkit._
+
+object AddressTerminatedTopicBenchSpec {
+
+  class Subscriber(testActor: ActorRef) extends Actor {
+    AddressTerminatedTopic(context.system).subscribe(self)
+    testActor ! "started"
+
+    override def postStop(): Unit = {
+      AddressTerminatedTopic(context.system).unsubscribe(self)
+    }
+
+    def receive = Actor.emptyBehavior
+  }
+}
+
+class AddressTerminatedTopicBenchSpec extends AkkaSpec("akka.loglevel=INFO") {
+  import AddressTerminatedTopicBenchSpec._
+
+  "Subscribe and unsubscribe of AddressTerminated" must {
+
+    "be quick" in {
+      val sys = ActorSystem(system.name + "2", system.settings.config)
+      try {
+        val num = 1000
+
+        val t1 = System.nanoTime()
+        val p = Props(new Subscriber(testActor))
+        val subscribers = Vector.fill(num)(sys.actorOf(p))
+        receiveN(num, 10.seconds)
+        log.info("Starting {} actors took {} ms", num, (System.nanoTime() - t1).nanos.toMillis)
+
+        val t2 = System.nanoTime()
+        shutdown(sys, 10.seconds, verifySystemShutdown = true)
+        log.info("Stopping {} actors took {} ms", num, (System.nanoTime() - t2).nanos.toMillis)
+      } finally {
+        if (!sys.isTerminated) shutdown(sys)
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
Fixed issue where the akka-js-actor-tests would not complete or Node.js reported a communication error. In test suite AddressTerminatedTopicBenchSpec the  test "Subscribe and unsubscribe of AddressTerminated be quick"  is expected to start 20,000 in 10 seconds. This may not be an attainable level of performance in The NodeJS runtime.  In addition due to an issue with the use of the Props[=> T](..) constructor resulting in the exception "TypeError: Cannot read property 'prototype' of undefined" for each actor, the performance was worsened. 
The fix was to set the number of actors to 1000, alternatively we could also change the timeout, however I am unsure of the impact of creating 20,000 actors in Node.JS
In addition, we changed the constructor employed to Props(classof[T},... for AddressTerminatedTopicBenchSpec and UidClashTest. There are 37 exception of this type in  this test module. Applying this change generally would remedy many of the failing tests in the module. 
