### PR TITLE
Fix IR checking errors

### DIFF
--- a/akka-js-actor-ir-patches/src/main/scala/ActorIrPatch.scala
+++ b/akka-js-actor-ir-patches/src/main/scala/ActorIrPatch.scala
@@ -6,7 +6,7 @@ trait ActorContext {
   def self: ActorRef
 }
 
-class Actor {
+trait Actor {
   implicit var context: ActorContext = null
   implicit final var self: ActorRef = null
 }

--- a/build.sbt
+++ b/build.sbt
@@ -177,9 +177,10 @@ lazy val akkaJsActor = crossProject.in(file("akka-js-actor"))
     compile in Compile := {
       val analysis = (compile in Compile).value
       val classDir = (classDirectory in Compile).value
-      val configFile = (baseDirectory in Compile).value / ".." / ".." / "config" / "ir_patch.config"
+      val hackDirs = (products in (akkaJsActorIrPatches, Compile)).value
 
-      org.akkajs.IrPatcherPlugin.patchThis(classDir, configFile)
+      for (hackDir <- hackDirs)
+        org.akkajs.IrPatcherPlugin.hackAllUnder(classDir, hackDir)
 
       analysis
     }
@@ -196,8 +197,7 @@ lazy val akkaJsActor = crossProject.in(file("akka-js-actor"))
   ).enablePlugins(spray.boilerplate.BoilerplatePlugin)
 
 lazy val akkaJsActorJS = akkaJsActor.js.dependsOn(
-  akkaJsUnsafe % "provided",
-  akkaJsActorIrPatches % "provided"
+  akkaJsUnsafe % "provided"
 )
 
 lazy val akkaJsTestkit = crossProject.in(file("akka-js-testkit"))
@@ -449,17 +449,6 @@ lazy val akkaJsActorIrPatches = Project(
     base = file("akka-js-actor-ir-patches")
    ).
    settings (
-    compile in Compile := {
-      val analysis = (compile in Compile).value
-      val classDir = (classDirectory in Compile).value
-      val base = (baseDirectory in Compile).value
-
-      val writer = new java.io.PrintWriter(base / ".." / "config" / "ir_patch.config", "UTF-8")
-      writer.print(classDir)
-      writer.flush
-      writer.close
-      analysis
-    },
     publishArtifact in Compile := true
   ).settings (commonSettings : _*
   ).enablePlugins (ScalaJSPlugin)

--- a/project/IrPatcherPlugin.scala
+++ b/project/IrPatcherPlugin.scala
@@ -111,15 +111,5 @@ object IrPatcherPlugin {
         patchHackedFile(base, hack)
       }
     } else {}
-
-  }
-
-  def patchThis(classDir: File, configFile: File): Unit = {
-    import java.nio.file.Files.readAllBytes
-    import java.nio.file.Paths.get
-
-    val hackClassDir = new File(new String(readAllBytes(get(configFile.getAbsolutePath))))
-
-    hackAllUnder(classDir, hackClassDir)
   }
 }


### PR DESCRIPTION
Together with the Scala.js PRs https://github.com/scala-js/scala-js/pull/3059 and https://github.com/scala-js/scala-js/pull/3061, this fixes the IR checking errors visible in `akkaJsActorJS/fastOptJS` and `akkaActorTestJS/test:fastOptJS`.

Unfortunately we cannot enable IR checking in this build yet, because that will only work after upgrading to Scala.js 0.6.19, once it is released.