### PR TITLE
More principled way of fetching IR patches.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -177,9 +177,10 @@ lazy val akkaJsActor = crossProject.in(file("akka-js-actor"))
     compile in Compile := {
       val analysis = (compile in Compile).value
       val classDir = (classDirectory in Compile).value
-      val configFile = (baseDirectory in Compile).value / ".." / ".." / "config" / "ir_patch.config"
+      val hackDirs = (products in (akkaJsActorIrPatches, Compile)).value
 
-      org.akkajs.IrPatcherPlugin.patchThis(classDir, configFile)
+      for (hackDir <- hackDirs)
+        org.akkajs.IrPatcherPlugin.hackAllUnder(classDir, hackDir)
 
       analysis
     }
@@ -196,8 +197,7 @@ lazy val akkaJsActor = crossProject.in(file("akka-js-actor"))
   ).enablePlugins(spray.boilerplate.BoilerplatePlugin)
 
 lazy val akkaJsActorJS = akkaJsActor.js.dependsOn(
-  akkaJsUnsafe % "provided",
-  akkaJsActorIrPatches % "provided"
+  akkaJsUnsafe % "provided"
 )
 
 lazy val akkaJsTestkit = crossProject.in(file("akka-js-testkit"))
@@ -449,17 +449,6 @@ lazy val akkaJsActorIrPatches = Project(
     base = file("akka-js-actor-ir-patches")
    ).
    settings (
-    compile in Compile := {
-      val analysis = (compile in Compile).value
-      val classDir = (classDirectory in Compile).value
-      val base = (baseDirectory in Compile).value
-
-      val writer = new java.io.PrintWriter(base / ".." / "config" / "ir_patch.config", "UTF-8")
-      writer.print(classDir)
-      writer.flush
-      writer.close
-      analysis
-    },
     publishArtifact in Compile := true
   ).settings (commonSettings : _*
   ).enablePlugins (ScalaJSPlugin)

--- a/project/IrPatcherPlugin.scala
+++ b/project/IrPatcherPlugin.scala
@@ -111,15 +111,5 @@ object IrPatcherPlugin {
         patchHackedFile(base, hack)
       }
     } else {}
-
-  }
-
-  def patchThis(classDir: File, configFile: File): Unit = {
-    import java.nio.file.Files.readAllBytes
-    import java.nio.file.Paths.get
-
-    val hackClassDir = new File(new String(readAllBytes(get(configFile.getAbsolutePath))))
-
-    hackAllUnder(classDir, hackClassDir)
   }
 }


### PR DESCRIPTION
Instead of writing the class directory to a config file, and *depending* on the `akkaJsActorIrPatches` project, we simply read `products in (akkaJsActorIrPatches, Compile)`.

In addition to being substandard in terms of sbt task dependency graph, the previous solution caused the classDirectory of the IR patches to end up in `akkaJsActor`'s `fullClasspath` (despite the `% "provided"`). Although this did not have an impact on published artifacts (AFAICT), it polluted the set of IR files seen in this build.

Extracted from #74.