### PR TITLE
Updated URLEncoder.encode encoding to be case insensitive

### DIFF
--- a/akka-js-actor/js/src/main/scala/java/net/URLEncoder.scala
+++ b/akka-js-actor/js/src/main/scala/java/net/URLEncoder.scala
@@ -7,7 +7,7 @@ import scala.scalajs.js
 object URLEncoder {
 
   def encode(s: String, enc: String): String = {
-    if (enc != "UTF-8")
+    if (enc.toUpperCase != "UTF-8")
       throw new UnsupportedEncodingException(enc)
     else
       js.Dynamic.global.encodeURI(s).asInstanceOf[String]


### PR DESCRIPTION
The JVM implementation of the `encode` method in `java.net.URLEncoder` is case insensitive with respect to the encoding name. However, the akka.js version is not in that it only supports uppercase "UTF-8". This PR makes the UTF-8 check case insensitive to be inline with the JVM implementation.

Credit to @an-tex for identifying the [issue](https://github.com/mliarakos/lagom-js/pull/1).